### PR TITLE
BUILDING.md: brew install openssl@3.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -65,9 +65,12 @@ To install dependencies on Mac and Linux
 
 Mac
 
+###### **NOTE: brew install openssl@3 installs an incorrect version**
+
 ``` cmd 
 brew install cmake
-brew install openssl
+brew install openssl@3.0
+brew link openssl@3.0
 ```
 
 Linux


### PR DESCRIPTION
This prompts the developer to install a compatible version of openssl (openssl-3.0.9) via `brew`.