### PR TITLE
header file mismatch base64_decode_tail_using_maps

### DIFF
--- a/src/nostril/base64.h
+++ b/src/nostril/base64.h
@@ -129,7 +129,7 @@ ssize_t base64_decode_quartet_using_maps(const base64_maps_t* maps,
  * @note sets errno = EDOM if src contains invalid characters
  * @note sets errno = EINVAL if src is an invalid base64 tail
  */
-ssize_t base64_decode_tail_using_maps(const base64_maps_t* maps, char* dest,
+ssize_t base64_decode_tail_using_maps(const base64_maps_t* maps, char dest[3],
   const char* src, size_t srclen);
 
 


### PR DESCRIPTION
header file mismatch base64_decode_tail_using_maps